### PR TITLE
Remove Google Analytics

### DIFF
--- a/_aux/feed.xml
+++ b/_aux/feed.xml
@@ -1,8 +1,0 @@
----
-title: Feed
-position: 0
-show: aux
-layout: 
----
-
-{% include feed.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,9 +8,9 @@
 <link href="https://fonts.googleapis.com/css?family=Passion+One:700|Roboto:300,400,400i,500,500i,700,700i,900,900i" rel="stylesheet">
 
 <!-- Favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
 <link rel="manifest" href="/assets/favicon/manifest.json">
 <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#da5647">
 <link rel="shortcut icon" href="/assets/favicon/favicon.ico">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,18 +25,6 @@
 <!-- Netlify Identity Widget -->
 <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 
-<!-- Google Analytics -->
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-63803105-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
 <!-- Facebook, Twitter, and URL Expanding Settings -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
@@ -125,16 +113,12 @@
 <meta name="monetization" content="$pay.stronghold.co/1a1d1b6226199ae451c805b09eff48bf7fe">
 {% endif %}
 
-
-
-
 <!-- Media Player
 <link rel="stylesheet" href="/build/mediaelementplayer.css"/>
 <script>
   $(document).ready(function() { $('video, audio').mediaelementplayer(); });
 </script>
 -->
-
 
 <script src="/js/timeJump.js"></script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,12 +20,11 @@
 <!-- FontAwesome -->
 <script src="https://kit.fontawesome.com/65bce7303d.js" crossorigin="anonymous"></script>
 
-{% assign show = site.data.shows[page.show] %}
-
 <!-- Netlify Identity Widget -->
 <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 
 <!-- Facebook, Twitter, and URL Expanding Settings -->
+{% assign show = site.data.shows[page.show] %}
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
 {% if page.layout == "shows" %}
@@ -62,26 +61,26 @@
 <meta name="twitter:description" value="{{ page.description }}" />
 <meta name="apple-itunes-app" content="app-id={{ show.appid }}, affiliate-data=at=10l4Ki&ct=websiteeps">
 {% if page.video and page.image %}
-  <meta name="twitter:card" content="player">
-  <meta name="twitter:player" value="{{ page.video }}" />
-  <meta name="twitter:player:width" content="1280" />
-	<meta name="twitter:player:height" content="720" />
-  {% if page.image contains '/uploads/' %}
-  <meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />
-  <meta property="og:image" content="{{ site.url }}{{ page.image }}" />
-  {% else %}
-  <meta property="twitter:image" content="{{ page.image }}" />
-  <meta property="og:image" content="{{ page.image }}" />
-  {% endif %}
+<meta name="twitter:card" content="player">
+<meta name="twitter:player" value="{{ page.video }}" />
+<meta name="twitter:player:width" content="1280" />
+<meta name="twitter:player:height" content="720" />
+{% if page.image contains '/uploads/' %}
+<meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />
+<meta property="og:image" content="{{ site.url }}{{ page.image }}" />
+{% else %}
+<meta property="twitter:image" content="{{ page.image }}" />
+<meta property="og:image" content="{{ page.image }}" />
+{% endif %}
 {% elsif page.image %}
-  <meta name="twitter:card" content="summary_large_image">
-  {% if page.image contains '/uploads/' %}
-  <meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />
-  <meta property="og:image" content="{{ site.url }}{{ page.image }}" />
-  {% else %}
-  <meta property="twitter:image" content="{{ page.image }}" />
-  <meta property="og:image" content="{{ page.image }}" />
-  {% endif %}
+<meta name="twitter:card" content="summary_large_image">
+{% if page.image contains '/uploads/' %}
+<meta name="twitter:image" content="{{ site.url }}{{ page.image }}" />
+<meta property="og:image" content="{{ site.url }}{{ page.image }}" />
+{% else %}
+<meta property="twitter:image" content="{{ page.image }}" />
+<meta property="og:image" content="{{ page.image }}" />
+{% endif %}
 {% else %}
 <meta name="twitter:card" content="summary">
 <meta name="twitter:image" content="{{ site.url }}{{ show.artwork }}" />
@@ -113,16 +112,4 @@
 <meta name="monetization" content="$pay.stronghold.co/1a1d1b6226199ae451c805b09eff48bf7fe">
 {% endif %}
 
-<!-- Media Player
-<link rel="stylesheet" href="/build/mediaelementplayer.css"/>
-<script>
-  $(document).ready(function() { $('video, audio').mediaelementplayer(); });
-</script>
--->
-
 <script src="/js/timeJump.js"></script>
-
-<!-- Time Jump (old player support files)
-<script src="/build/jquery.js"></script>
-<script src="/build/mediaelement-and-player.min.js"></script>
--->


### PR DESCRIPTION
In an effort to reduce the overall size and unnecessary services and scripts, we can remove Google Analytics scripts and reorganize the <head> include. Instead, we'll be using public stats via [Fathom Analytics](https://app.usefathom.com/share/sxmvrafs/goodstuff.fm#/?from=2020-04-11%2000%3A00%3A00&site=4452&to=2020-04-18%2023%3A59%3A59).

This change also fixes linking in the <head> include for favicon links I noticed while editing that document.