### PR TITLE
Fixes mobile button links

### DIFF
--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -23,24 +23,24 @@
             <li class="episode__show__hosts">Hosted by {{ show.hosts }}</li>
             <li class="episode__show__description">{{ show.description | truncate: 256 | markdownify }}</li>
             <li class="episode__show__links">
-              <button class="rss"><a href="{{ show.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
+              <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
               {% if show.itunes %}
-              <button type="button" class="apple"><a href="{{ show.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
+              <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
               {% endif %}
               {% if show.pocketcasts %}
-              <button type="button" class="pocketcasts"><a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
+              <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
               {% endif %}
               {% if show.overcast %}
-              <button type="button" class="overcast"><a href="{{ show.overcast }}" title="Subscribe on Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+              <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
               {% endif %}
               {% if show.youtube %}
-              <button type="button" class="youtube"><a href="{{ show.youtube }}" title="Subscribe on YouTube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</a>
+              <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button></a>
               {% endif %}
               {% if show.anchor %}
-              <button type="button" class="anchor"><a href="{{ show.anchor }}" title="Subscribe on Anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</a>
+              <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button></a>
               {% endif %}
               {% if show.spotify %}
-              <button type="button" class="spotify"><a href="{{ show.spotify }}" title="Subscribe on Spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</a>
+              <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>
               {% endif %}
             </li>
         </ul>

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -17,21 +17,21 @@
             <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
             <li class="shows__list__description">{{ show.description | truncate: 384 }}</li>
             <li class="shows__list__link">
-              <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
+              <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
               {% if show.itunes %}
-                <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
+                <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
               {% endif %}
               {% if show.pocketcasts %}
-                <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
+                <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
               {% endif %}
               {% if show.overcast %}
-                <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
+                <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
               {% endif %}
               {% if show.youtube %}
-                <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
+                <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button></a>
               {% endif %}
               {% if show.anchor %}
-                <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
+                <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button></a>
               {% endif %}
             {% if show.spotify %}
                 <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>

--- a/_layouts/show.html
+++ b/_layouts/show.html
@@ -17,24 +17,24 @@
             <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
             <li class="shows__list__description">{{ show.description | truncate: 384 }}</li>
             <li class="shows__list__link">
-              <button class="rss"><a href="{{ show.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
+              <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
               {% if show.itunes %}
-                <button type="button" class="apple"><a href="{{ show.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
+                <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
               {% endif %}
               {% if show.pocketcasts %}
-                <button type="button" class="pocketcasts"><a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
+                <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
               {% endif %}
               {% if show.overcast %}
-                <button type="button" class="overcast"><a href="{{ show.overcast }}" title="Subscribe on Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+                <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
               {% endif %}
               {% if show.youtube %}
-                <button type="button" class="youtube"><a href="{{ show.youtube }}" title="Subscribe on YouTube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</a>
+                <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
               {% endif %}
               {% if show.anchor %}
-                <button type="button" class="anchor"><a href="{{ show.anchor }}" title="Subscribe on Anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</a>
+                <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
               {% endif %}
             {% if show.spotify %}
-                <button type="button" class="spotify"><a href="{{ show.spotify }}" title="Subscribe on Spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</a>
+                <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>
             {% endif %}
             </li>
         </ul>

--- a/_layouts/shows.html
+++ b/_layouts/shows.html
@@ -29,10 +29,10 @@
                 <li class="shows__list__description">{{ master.description }}</li>
 
                 <li class="shows__list__link">
-                  <button class="rss"><a href="{{ master.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
-                  <button type="button" class="apple"><a href="{{ master.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
-                  <button type="button" class="pocketcasts"><a href="{{ master.pocketcasts }}" title="Subscribe in Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
-                  <button type="button" class="overcast"><a href="{{ master.overcast }}" title="Subscribe in Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+                  <a href="{{ master.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
+                  <a href="{{ master.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
+                  <a href="{{ master.pocketcasts }}" title="Subscribe in Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
+                  <a href="{{ master.overcast }}" title="Subscribe in Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
                 </li>
             </ul>
 
@@ -49,24 +49,24 @@
                 <li class="shows__list__description">{{ show.description | truncate: 256 }}</li>
 
                 <li class="shows__list__link">
-                  <button class="rss"><a href="{{ show.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
+                  <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
                   {% if show.itunes %}
-                    <button type="button" class="apple"><a href="{{ show.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <button type="button" class="pocketcasts"><a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
                   {% endif %}
                   {% if show.overcast %}
-                    <button type="button" class="overcast"><a href="{{ show.overcast }}" title="Subscribe on Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
                   {% endif %}
                   {% if show.youtube %}
-                    <button type="button" class="youtube"><a href="{{ show.youtube }}" title="Subscribe on YouTube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</a>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
                   {% endif %}
                   {% if show.anchor %}
-                    <button type="button" class="anchor"><a href="{{ show.anchor }}" title="Subscribe on Anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</a>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
                   {% endif %}
                 {% if show.spotify %}
-                    <button type="button" class="spotify"><a href="{{ show.spotify }}" title="Subscribe on Spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</a>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
                 {% endif %}
                 </li>
             </ul>
@@ -90,24 +90,24 @@
                 <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
                 <li class="shows__list__description">{{ show.description }}</li>
                 <li class="shows__list__link">
-                    <button class="rss"><a href="{{ show.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
+                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
                   {% if show.itunes %}
-                    <button type="button" class="apple"><a href="{{ show.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <button type="button" class="pocketcasts"><a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
                   {% endif %}
                   {% if show.overcast %}
-                    <button type="button" class="overcast"><a href="{{ show.overcast }}" title="Subscribe on Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
                   {% endif %}
                   {% if show.youtube %}
-                    <button type="button" class="youtube"><a href="{{ show.youtube }}" title="Subscribe on YouTube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</a>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
                   {% endif %}
                   {% if show.anchor %}
-                    <button type="button" class="anchor"><a href="{{ show.anchor }}" title="Subscribe on Anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</a>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
                   {% endif %}
                 {% if show.spotify %}
-                    <button type="button" class="spotify"><a href="{{ show.spotify }}" title="Subscribe on Spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</a>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
                 {% endif %}
                 </li>
                 </li>
@@ -130,24 +130,24 @@
                 <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
                 <li class="shows__list__description">{{ show.description }}</li>
                 <li class="shows__list__link">
-                    <button class="rss"><a href="{{ show.rss }}"><i class="fa fa-rss" aria-hidden="true"></i>RSS</a>
+                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
                   {% if show.itunes %}
-                    <button type="button" class="apple"><a href="{{ show.itunes }}" title="Subscribe on Podcasts"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</a>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <button type="button" class="pocketcasts"><a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</a>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
                   {% endif %}
                   {% if show.overcast %}
-                    <button type="button" class="overcast"><a href="{{ show.overcast }}" title="Subscribe on Overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</a>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
                   {% endif %}
                   {% if show.youtube %}
-                    <button type="button" class="youtube"><a href="{{ show.youtube }}" title="Subscribe on YouTube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</a>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
                   {% endif %}
                   {% if show.anchor %}
-                    <button type="button" class="anchor"><a href="{{ show.anchor }}" title="Subscribe on Anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</a>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
                   {% endif %}
                 {% if show.spotify %}
-                    <button type="button" class="spotify"><a href="{{ show.spotify }}" title="Subscribe on Spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</a>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
                 {% endif %}
                 </li>
                 </li>

--- a/_layouts/shows.html
+++ b/_layouts/shows.html
@@ -29,10 +29,10 @@
                 <li class="shows__list__description">{{ master.description }}</li>
 
                 <li class="shows__list__link">
-                  <a href="{{ master.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
-                  <a href="{{ master.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
-                  <a href="{{ master.pocketcasts }}" title="Subscribe in Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
-                  <a href="{{ master.overcast }}" title="Subscribe in Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
+                  <a href="{{ master.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
+                  <a href="{{ master.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
+                  <a href="{{ master.pocketcasts }}" title="Subscribe in Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
+                  <a href="{{ master.overcast }}" title="Subscribe in Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
                 </li>
             </ul>
 
@@ -49,24 +49,24 @@
                 <li class="shows__list__description">{{ show.description | truncate: 256 }}</li>
 
                 <li class="shows__list__link">
-                  <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
+                  <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
                   {% if show.itunes %}
-                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
                   {% endif %}
                   {% if show.overcast %}
-                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
                   {% endif %}
                   {% if show.youtube %}
-                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button></a>
                   {% endif %}
                   {% if show.anchor %}
-                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button></a>
                   {% endif %}
                 {% if show.spotify %}
-                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>
                 {% endif %}
                 </li>
             </ul>
@@ -90,24 +90,24 @@
                 <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
                 <li class="shows__list__description">{{ show.description }}</li>
                 <li class="shows__list__link">
-                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
+                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
                   {% if show.itunes %}
-                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
                   {% endif %}
                   {% if show.overcast %}
-                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
                   {% endif %}
                   {% if show.youtube %}
-                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button></a>
                   {% endif %}
                   {% if show.anchor %}
-                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button></a>
                   {% endif %}
                 {% if show.spotify %}
-                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>
                 {% endif %}
                 </li>
                 </li>
@@ -130,24 +130,24 @@
                 <li class="shows__list__hosts">Hosted by {{ show.hosts | join: ', ' }}</li>
                 <li class="shows__list__description">{{ show.description }}</li>
                 <li class="shows__list__link">
-                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button>
+                    <a href="{{ show.rss }}"><button class="rss"><i class="fa fa-rss" aria-hidden="true"></i>RSS</button></a>
                   {% if show.itunes %}
-                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button>
+                    <a href="{{ show.itunes }}" title="Subscribe on Podcasts"><button type="button" class="apple"><i class="fab fa-apple" aria-hidden="true"></i>Podcasts</button></a>
                   {% endif %}
                   {% if show.pocketcasts %}
-                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button>
+                    <a href="{{ show.pocketcasts }}" title="Subscribe on Pocket Casts"><button type="button" class="pocketcasts"><i class="fa fa-headphones" aria-hidden="true"></i>Pocket Casts</button></a>
                   {% endif %}
                   {% if show.overcast %}
-                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button>
+                    <a href="{{ show.overcast }}" title="Subscribe on Overcast"><button type="button" class="overcast"><i class="fa fa-headphones" aria-hidden="true"></i>Overcast</button></a>
                   {% endif %}
                   {% if show.youtube %}
-                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button>
+                    <a href="{{ show.youtube }}" title="Subscribe on YouTube"><button type="button" class="youtube"><i class="fa fa-youtube" aria-hidden="true"></i>Youtube</button></a>
                   {% endif %}
                   {% if show.anchor %}
-                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button>
+                    <a href="{{ show.anchor }}" title="Subscribe on Anchor"><button type="button" class="anchor"><i class="fa fa-anchor" aria-hidden="true"></i>Anchor</button></a>
                   {% endif %}
                 {% if show.spotify %}
-                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button>
+                    <a href="{{ show.spotify }}" title="Subscribe on Spotify"><button type="button" class="spotify"><i class="fab fa-spotify" aria-hidden="true"></i>Spotify</button></a>
                 {% endif %}
                 </li>
                 </li>

--- a/styles/_type.scss
+++ b/styles/_type.scss
@@ -3,19 +3,25 @@
 // Styles for fonts, weights, sizes, and other font-related styles.
 
 button {
-  border: 0;
-  border-radius: 0.4rem;
+  //thick border style
+  //border: 6 solid;
+  //border-width: thick;
+  //border-color: black;
+  border: none;
   font-family: system-ui, sans-serif;
-  font-size: 1.05rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: white;
+  border-radius: 8pt;
   line-height: 1.2;
   white-space: nowrap;
   text-decoration: none;
   padding: 0.5rem 0.8rem;
   margin-right: 0.5rem;
-  margin-top: 1.5rem;
+  margin-top: 1rem;
+  min-height: 40px;
   cursor: pointer;
     a {
-      color: white !important;
       text-decoration: none !important;
     }
     i {

--- a/styles/mobile.scss
+++ b/styles/mobile.scss
@@ -101,16 +101,13 @@
     display: none;
   }
 
-  .episode__show__artwork, .episode__show__hosts, .episode__show__description {
+  .episode__show__artwork, .episode__show__hosts, .episode__show__description, .episode__show__links {
     display: none;
   }
 
   .episode__show__name {
+    font-size: 1.8rem;
     padding-top: 24pt !important;
-    padding-bottom: 16pt;
-  }
-
-  .episode__show__link img {
     padding-bottom: 8pt;
   }
 

--- a/styles/mobile.scss
+++ b/styles/mobile.scss
@@ -11,6 +11,33 @@
     overflow: auto;
   }
 
+  button {
+    //thick border style
+    //border: 6 solid;
+    //border-width: thick;
+    //border-color: black;
+    border: none;
+    font-family: system-ui, sans-serif;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: white !important;
+    border-radius: 22pt;
+    line-height: 1.2;
+    white-space: nowrap;
+    text-decoration: none;
+    padding: 0.5rem 0.8rem;
+    margin-right: 0.5rem;
+    margin-top: 1rem;
+    cursor: pointer;
+      a {
+
+        text-decoration: none !important;
+      }
+      i {
+        padding-right: 6px;
+      }
+  }
+
   .container {
     padding-left: 1.2rem !important;
     padding-right: 1.2rem !important;


### PR DESCRIPTION
With the addition of mobile subscription buttons, the order of a href and button made only the text tappable on mobile devices. This PR fixes that, restyles the buttons on mobile, and removes them from the episode template for quicker visibility of the episode notes when shared out.